### PR TITLE
fix: i18n用ロケールファイルにハッシュ形式でデータをいれる

### DIFF
--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        display_name: 名前

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  helpers:
+  users:
+    new:
+      title: ユーザー登録
+  header:


### PR DESCRIPTION
## 変更の概要

* 変更の概要
　500エラーが発生したのでバグ修正
* 関連するIssueやプルリクエスト なし

## なぜこの変更をするのか(修正の場合に使用)

* 変更をする理由　ロケールファイルが空になっていたことで500エラーが発生

## やったこと

* [x] config/locales/activerecord/ja.ymlおよびconfig/locales/views/ja.ymlにハッシュ形式でデータ入力