### PR TITLE
feat: GitHub actionsを用いてFly.ioへのデプロイを自動化する

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,15 @@
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## 変更の概要

* 変更の概要　GitHub actionsにFLY_API_TOKENを設定し、.github/workflow/fly.ymlにワークフローを作成した
* 関連するIssueやプルリクエスト close: #83 

## やったこと

* [x] `flyctl tokens create deploy -x 999999h`をアプリのルートディレクトリで実行し、トークンをコピー
* [x] レポジトリーのGitHubのsection→Secrets and variablesのActionsで`New repository secret`し、名称を`FLY_API_TOKEN`, 上のトークンをsecretsにペースト
* [x] .github/workflow/fly.ymlをアプリのルートディレクトリ直下に作成し、公式Docsを参考にコード記述

## 影響範囲

* `main`ブランチにプッシュすることでデプロイが自動で行われるようになり、デプロイの手間が省かれる

## 課題

* CI環境も一緒に作成した方がいいだろうか。