### PR TITLE
feat: webhook&LINE Messaging API学習してオウム返しさせる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,9 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+
+  # modelのスキーマをコメントアウトで表示するgem
+  gem "annotate"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,6 @@ gem "dotenv-rails"
 
 # JSにRailsから変数を渡すためのgem
 gem "gon"
+
+# LINE Messaging APIを使うためのgem
+gem 'line-bot-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     bindex (0.8.1)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
@@ -251,6 +254,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   capybara
   cssbundling-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
+    line-bot-api (1.28.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -264,6 +265,7 @@ DEPENDENCIES
   gon
   jbuilder
   jsbundling-rails
+  line-bot-api
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.8)

--- a/app/controllers/floss_records_controller.rb
+++ b/app/controllers/floss_records_controller.rb
@@ -1,0 +1,33 @@
+class FlossRecordsController < ApplicationController
+  before_action :login_required
+
+  def index
+    @floss_records = current_user.floss_records.order(record_date: :desc)
+  end
+
+  def create
+    @floss_record = current_user.floss_records.new(floss_record_params)
+    last_record = current_user.floss_records.order(date: :desc).first
+
+    if last_record && last_record.date == Date.yesterday
+      @floss_record.consecutive_count = last_record.consecutive_count + 1
+    else
+      @floss_record.consecutive_count = 1
+    end
+
+    if @floss_record.save
+      # 成功した場合の処理
+      redirect_to profile_path, notice: 'フロス実施記録を作成しました。'
+    else
+      # エラーがある場合の処理
+      flash.now[:alert] = 'エラーが発生しました。'
+      render :new
+    end
+  end
+
+  private
+
+  def floss_record_params
+    params.require(:floss_record).permit(:record_date)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,11 @@ class UsersController < ApplicationController
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
+  def show
+    @user = current_user
+    @floss_records = @user.floss_records.order(record_date: :desc)
+  end
+
   private
 
   def authenticate_line_user(id_token)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,7 @@ class UsersController < ApplicationController
   def show
     @user = current_user
     @floss_records = @user.floss_records.order(record_date: :desc)
+    @latest_record = @floss_records.first
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_liff_id, only: [:new]
+  before_action :login_required, only: [:show]
   require 'net/http'
   require 'uri'
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,0 +1,38 @@
+class WebhookController < ApplicationController
+  require 'line/bot'  # gem 'line-bot-api'
+
+  protect_from_forgery except: :callback
+
+  def callback
+    body = request.body.read
+    signature = request.env['HTTP_X_LINE_SIGNATURE']
+
+    unless client.validate_signature(body, signature)
+      head :bad_request
+    end
+
+    events = client.parse_events_from(body)
+
+    events.each { |event|
+      # テキストメッセージが送られた場合の処理
+      if event.is_a?(Line::Bot::Event::Message) && event.type == Line::Bot::Event::MessageType::Text
+        message = {
+          type: 'text',
+          text: event.message['text'] # ユーザーからのテキストをそのまま返す
+        }
+        client.reply_message(event['replyToken'], message)
+      end
+    }
+
+    head :ok
+  end
+
+  private
+
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+    }
+  end
+end

--- a/app/models/floss_record.rb
+++ b/app/models/floss_record.rb
@@ -1,0 +1,15 @@
+class FlossRecord < ApplicationRecord
+  belongs_to :user
+
+  validates :record_date, presence: true
+  validate :date_is_yesterday_or_today
+  validates :consecutive_count, numericality: { greater_than_or_equal_to: 0 }
+
+  private
+
+  def date_is_yesterday_or_today
+    if record_date.present? && record_date != Date.today && record_date != Date.yesterday
+      errors.add(:record_date, :record_date_must_be)
+    end
+  end
+end

--- a/app/models/floss_record.rb
+++ b/app/models/floss_record.rb
@@ -4,7 +4,7 @@
 #
 #  id                :bigint           not null, primary key
 #  consecutive_count :integer          default(0)
-#  record_date       :date             not null
+#  record_date       :date
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  user_id           :bigint           not null
@@ -21,7 +21,6 @@
 class FlossRecord < ApplicationRecord
   belongs_to :user
 
-  validates :record_date, presence: true
   validate :date_is_yesterday_or_today
   validates :consecutive_count, numericality: { greater_than_or_equal_to: 0 }
 

--- a/app/models/floss_record.rb
+++ b/app/models/floss_record.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: floss_records
+#
+#  id                :bigint           not null, primary key
+#  consecutive_count :integer          default(0)
+#  record_date       :date             not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_floss_records_on_user_id                  (user_id)
+#  index_floss_records_on_user_id_and_record_date  (user_id,record_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class FlossRecord < ApplicationRecord
   belongs_to :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,17 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id           :bigint           not null, primary key
+#  display_name :string           not null
+#  image        :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  line_user_id :string           not null
+#
 class User < ApplicationRecord
+  has_many :floss_records, dependent: :destroy
+
   validates :line_user_id, presence: true, uniqueness: true
   validates :display_name, presence: true
 end

--- a/app/views/floss_records/create.html.erb
+++ b/app/views/floss_records/create.html.erb
@@ -1,0 +1,2 @@
+<h1>FlossRecords#create</h1>
+<p>Find me in app/views/floss_records/create.html.erb</p>

--- a/app/views/users/create.html.erb
+++ b/app/views/users/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Users#create</h1>
-<p>Find me in app/views/users/create.html.erb</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:title, t('.title')) %>
+<section class="container mx-auto px-4 sm:px-6">
+  <div class="bg-white shadow-lg rounded-lg p-4 sm:p-6 md:p-8 mb-10">
+    <div class="flex items-center mb-6">
+      <%= image_tag @user.image, alt: @user.display_name, class: "rounded-full h-20 w-20 mr-4" %>
+      <h2 class="text-xl sm:text-2xl font-semibold text-gray-800"><%= @user.display_name %></h2>
+    </div>
+
+    <div class="text-gray-600">
+      <p class="mb-4">フロス実施日数: <%= @user.floss_records.count %>日</p>
+      <p>連続フロス日数: <%= @user.floss_records.order(record_date: :desc).first.consecutive_count %>日</p>
+    </div>
+  </div>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
 
     <div class="text-gray-600">
       <p class="mb-4">フロス実施日数: <%= @user.floss_records.count %>日</p>
-      <p>連続フロス日数: <%= @user.floss_records.order(record_date: :desc).first.consecutive_count %>日</p>
+      <p>連続フロス日数: <%= @latest_record ? @latest_record.consecutive_count : 0 %>日</p>
     </div>
   </div>
 </section>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,6 +2,15 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      floss_record: フロス記録
     attributes:
       user:
         display_name: 名前
+      floss_record:
+        record_date: 実施日
+    errors:
+      models:
+        floss_record:
+          attributes:
+            record_date:
+              record_date_must_be: "は今日または昨日でなければなりません。"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,4 +8,6 @@ ja:
   users:
     new:
       title: ユーザー登録
+    show:
+      title: プロフィール
   header:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,7 @@ Rails.application.routes.draw do
   get '/after_login', to: 'static_pages#after_login'
   resource :user, only: %i[new create]
   resource :profile, controller: 'users', only: [:show]
+
+  # webhook
+  post '/callback', to: 'webhook#callback'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
 
   get '/after_login', to: 'static_pages#after_login'
   resource :user, only: %i[new create]
+  resource :profile, controller: 'users', only: [:show]
 end

--- a/db/migrate/20240121031004_create_floss_records.rb
+++ b/db/migrate/20240121031004_create_floss_records.rb
@@ -1,0 +1,13 @@
+class CreateFlossRecords < ActiveRecord::Migration[7.0]
+  def change
+    create_table :floss_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :record_date, null: false
+      t.integer :consecutive_count, default: 0
+
+      t.timestamps
+    end
+
+    add_index :floss_records, [:user_id, :record_date], unique: true
+  end
+end

--- a/db/migrate/20240121074156_changerails.rb
+++ b/db/migrate/20240121074156_changerails.rb
@@ -1,0 +1,5 @@
+class Changerails < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :floss_records, :record_date, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_21_031004) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_21_074156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "floss_records", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.date "record_date", null: false
+    t.date "record_date"
     t.integer "consecutive_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_20_053557) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_21_031004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "floss_records", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "record_date", null: false
+    t.integer "consecutive_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "record_date"], name: "index_floss_records_on_user_id_and_record_date", unique: true
+    t.index ["user_id"], name: "index_floss_records_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "line_user_id", null: false
@@ -22,4 +32,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_20_053557) do
     t.string "image"
   end
 
+  add_foreign_key "floss_records", "users"
 end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
## 変更の概要

* 変更の概要
* gem line-bot-apiを導入、webhook用のコントローラーを作成し、LINEトーク上でオーム返しできるようにする
* 関連するIssueやプルリクエスト
close: #57 
close: #56 
close: #60 

## やったこと

* [x] gem line-bot-apiをインストール
* [x] webhookコントローラーを作成
* [x] callbackアクションのルーティング設定
* [x] LINE Messaging APIのchannel_secret, channel_tokenを.envに追記
* [x] LINE consoleでwebhook URL登録
* [x] フロス実施記録用のfloss_records tableを作成 

## 備考
* フロス実施記録用のtable作成はここでやらなくてもよかったかも。
