### PR TITLE
Feature: LINEトーク上でフロス実施記録を対話形式でつけて保存する

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -13,16 +13,14 @@ class WebhookController < ApplicationController
 
     events = client.parse_events_from(body)
 
-    events.each { |event|
-      # テキストメッセージが送られた場合の処理
-      if event.is_a?(Line::Bot::Event::Message) && event.type == Line::Bot::Event::MessageType::Text
-        message = {
-          type: 'text',
-          text: event.message['text'] # ユーザーからのテキストをそのまま返す
-        }
-        client.reply_message(event['replyToken'], message)
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Message
+        handle_message_event(event)
+      when Line::Bot::Event::Postback
+        handle_postback_event(event)
       end
-    }
+    end
 
     head :ok
   end
@@ -34,5 +32,65 @@ class WebhookController < ApplicationController
       config.channel_secret = ENV['LINE_CHANNEL_SECRET']
       config.channel_token = ENV['LINE_CHANNEL_TOKEN']
     }
+  end
+
+  def handle_message_event(event)
+    case event.type
+    when Line::Bot::Event::MessageType::Text
+      case event.message['text']
+      when 'フロス記録をつける'
+        message = {
+          type: 'template',
+          altText: 'ナイスフロス！いつの記録をつけますか？',
+          template: {
+            type: 'buttons',
+            text: 'ナイスフロス！いつの記録をつけますか？',
+            actions: [
+              {
+                type: 'postback',
+                label: '昨日',
+                data: 'date=yesterday'
+              },
+              {
+                type: 'postback',
+                label: '今日',
+                data: 'date=today'
+              }
+            ]
+          }
+        }
+        client.reply_message(event['replyToken'], message)
+      end
+    end
+  end
+
+  def handle_postback_event(event)
+    data = Rack::Utils.parse_nested_query(event['postback']['data'])
+    record_date = case data['date']
+                  when 'yesterday'
+                    Time.zone.yesterday
+                  when 'today'
+                    Time.zone.today
+                  end
+
+    if record_date
+      user = find_or_create_user(event['source']['userId'])
+      result = create_floss_record(user, record_date) if user
+      response_message = { type: 'text', text: result[:message] }
+      client.reply_message(event['replyToken'], response_message)
+    end
+  end
+
+  def find_or_create_user(line_user_id)
+    User.find_or_create_by(line_user_id: line_user_id)
+  end
+
+  def create_floss_record(user, record_date)
+    floss_record = user.floss_records.new(record_date: record_date)
+    if floss_record.save
+      { success: true, message: "#{record_date}のフロス記録を保存しました。" }
+    else
+      { success: false, message: floss_record.errors.full_messages.join(", ") }
+    end
   end
 end

--- a/app/models/floss_record.rb
+++ b/app/models/floss_record.rb
@@ -30,7 +30,7 @@ class FlossRecord < ApplicationRecord
 
   # 実施記録を保存する前に、連続実施日数を更新する
   def update_consecutive_count
-    last_record = user.floss_records.order(record_date: :desc).second
+    last_record = user.floss_records.order(record_date: :desc).first
 
     if last_record && (record_date - last_record.record_date).to_i <= 2
       # 前回の記録から2日以内の場合、連続実施日数をインクリメント

--- a/app/models/floss_record.rb
+++ b/app/models/floss_record.rb
@@ -21,14 +21,26 @@
 class FlossRecord < ApplicationRecord
   belongs_to :user
 
-  validate :date_is_yesterday_or_today
-  validates :consecutive_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :record_date, uniqueness: { scope: :user_id }
+  validates :consecutive_count, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7 }
+
+  before_save :update_consecutive_count
 
   private
 
-  def date_is_yesterday_or_today
-    if record_date.present? && record_date != Date.today && record_date != Date.yesterday
-      errors.add(:record_date, :record_date_must_be)
+  # 実施記録を保存する前に、連続実施日数を更新する
+  def update_consecutive_count
+    last_record = user.floss_records.order(record_date: :desc).second
+
+    if last_record && (record_date - last_record.record_date).to_i <= 2
+      # 前回の記録から2日以内の場合、連続実施日数をインクリメント
+      self.consecutive_count = last_record.consecutive_count + 1
+    else
+      # 3日以上空いた場合、連続実施日数を0にリセット
+      self.consecutive_count = 0
     end
+
+    # 連続実施日数を7日で制限
+    self.consecutive_count = 7 if self.consecutive_count > 7
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,11 +18,12 @@ module App
       g.skip_routes true
     end
 
+    # default localeを日本語に設定
     config.i18n.default_locale = :ja
+    # タイムゾーンを東京に設定
+    config.time_zone = 'Tokyo'
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
## 変更の概要

* 変更の概要
* 「フロス実施記録をつける」とLINEトーク上で送るとポストバックアクションで「今日」「昨日」と応答がある
* 選んだ日付を応答メッセージで表示。
* 選んだ日付をFlossRecordレコードに保存。
* 関連するIssueやプルリクエスト
close: #58 
close: #62 

## やったこと

* [x] webhookコントローラーを修正し、LINE Messaging APIのポストバックアクションを設定
* [x] LINEリッチメニューでポストバックアクションが発生する特定のテキストが送信されるように設定
* [x] 取得した日付データがFlossRecordに保存されるように設定
* [x] 取得した日付が標準時(UTC 0:00)であったため日本時間になるようにconfig/application.rbに追記
* [x] record_dataの日付にもとづき、consecutive_recordカラムが変化するように設定

## 備考
* 日付選択アクションではカレンダー表示で好きな日付が選べてしまう。
* 今日もしくは昨日の日付のみが選択できるようにしたかったため、ポストバックアクションにした。