### PR TITLE
feat: Googleフォームでお問い合わせフォームを作成し、リンクで実装

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -10,7 +10,7 @@
     <div class="flex flex-col items-start sm:items-end">
       <%= link_to '利用規約', terms_of_service_path, class: 'text-gray-800 hover:text-gray-600 mb-2' %>
       <%= link_to 'プライバシーポリシー', privacy_policy_path, class: 'text-gray-800 hover:text-gray-600 mb-2' %>
-      <%= link_to 'お問い合わせ', '#', class: 'text-gray-800 hover:text-gray-600' %>
+      <%= link_to 'お問い合わせ', 'https://forms.gle/UbREx8vY3SfVkeTa9', target: "_blank", rel: "noopener noreferrer", class: 'text-gray-800 hover:text-gray-600' %>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## 変更の概要

* Googleフォームでお問い合わせフォームを作成し、リンクで実装
* 関連するIssueやプルリクエスト
close: #50 

## やったこと

* [x] Googleフォームでお問い合わせフォームを作成した
* [ ] footer.html.erb内でlink_toを用いてお問い合わせフォームへリンクするように設定した
* [ ] `target: "_blank", rel: "noopener noreferrer"`属性を追記した

## 課題

* ActionMailerを使用したお問い合わせフォームの作成方法もある。MVP後に変更していく。