### PR TITLE
feat: ユーザーの物理削除機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user, :logged_in?, :login_required
+  add_flash_types :success
 
   private
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_liff_id, only: [:new]
-  before_action :login_required, only: [:show]
+  before_action :login_required, only: %i[show destroy]
   require 'net/http'
   require 'uri'
 
@@ -20,6 +20,13 @@ class UsersController < ApplicationController
     @user = current_user
     @floss_records = @user.floss_records.order(record_date: :desc)
     @latest_record = @floss_records.first
+  end
+
+  def destroy
+    @user = current_user
+    @user.destroy
+    reset_session
+    redirect_to root_path, status: :see_other, success: 'アカウントが削除されました。'
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
 
   <body>
     <%= render 'shared/header' %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
     <script charset="utf-8" src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div role="alert" class="alert alert-<%= message_type %>">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,5 +10,6 @@
       <p class="mb-4">フロス実施日数: <%= @user.floss_records.count %>日</p>
       <p>連続フロス日数: <%= @latest_record ? @latest_record.consecutive_count : 0 %>日</p>
     </div>
+    <%= link_to 'アカウントを削除する', user_path, data: { turbo_method: :delete, turbo_confirm: '本当に削除してもいいですか？' }, class: 'btn btn-accent btn-sm' %>
   </div>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get '/privacy_policy', to: 'static_pages#privacy_policy'
 
   get '/after_login', to: 'static_pages#after_login'
-  resource :user, only: %i[new create]
+  resource :user, only: %i[new create destroy]
   resource :profile, controller: 'users', only: [:show]
 
   # webhook


### PR DESCRIPTION
## 変更の概要

* ユーザーを物理削除できるようにした
* 関連するIssueやプルリクエスト close: #100 

## やったこと

* [x] User controllerにdestroyアクションを作成
* [x] routes.rbでuserのルーティングにdestroyを追記
* [x] users/show.html.erbに削除ボタンを作成
* [x] shared/_flash_message.html.erbを作成
* [x] application.html.erbにrender shared/flash_message''を追記
* [x] application_controller.rbにadd_flash_types :successを追記

## 課題

* 削除ボタンにはdaisyUIのスタイルが適応されているが、フラッシュメッセージに適応されていない？
