### PR TITLE
hotfix: update_consecutive_countメソッドを修正して、2日以上空いた場合の１にリセットへ変更

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -131,7 +131,6 @@ class WebhookController < ApplicationController
 
   def select_image_url(consecutive_count)
     case consecutive_count
-    when 0 then "https://floss-buddy-message.s3.ap-northeast-1.amazonaws.com/achievement_images/quitter.png"
     when 1 then "https://floss-buddy-message.s3.ap-northeast-1.amazonaws.com/achievement_images/Day_1.png"
     when 2 then "https://floss-buddy-message.s3.ap-northeast-1.amazonaws.com/achievement_images/Day_2.png"
     when 3 then "https://floss-buddy-message.s3.ap-northeast-1.amazonaws.com/achievement_images/Day_3.png"

--- a/app/models/floss_record.rb
+++ b/app/models/floss_record.rb
@@ -22,7 +22,7 @@ class FlossRecord < ApplicationRecord
   belongs_to :user
 
   validates :record_date, uniqueness: { scope: :user_id }
-  validates :consecutive_count, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7 }
+  validates :consecutive_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   before_save :update_consecutive_count
 
@@ -32,15 +32,12 @@ class FlossRecord < ApplicationRecord
   def update_consecutive_count
     last_record = user.floss_records.order(record_date: :desc).first
 
-    if last_record && (record_date - last_record.record_date).to_i <= 2
-      # 前回の記録から2日以内の場合、連続実施日数をインクリメント
+    if last_record && (record_date - last_record.record_date).to_i == 1
+      # 前回の記録から1日だけ空いた場合、連続実施日数をインクリメント
       self.consecutive_count = last_record.consecutive_count + 1
     else
-      # 3日以上空いた場合、連続実施日数を0にリセット
-      self.consecutive_count = 0
+      # 2日以上空いた場合、連続実施日数を1にリセット
+      self.consecutive_count = 1
     end
-
-    # 連続実施日数を7日で制限
-    self.consecutive_count = 7 if self.consecutive_count > 7
   end
 end


### PR DESCRIPTION
## 変更の概要

* 2日以上あいた後に実施記録をつけると連続実施記録が0から始まっていたので、1に修正した。
* consecutive_countを7が上限にしていたが、撤廃した
* 関連するIssueやプルリクエスト　なし

## やったこと

* [x] floss_record.rbでupdate_consecutive_countを修正
* [x] consecutive_countの上限がなくなるようにバリデーションと update_consecutive_count内のコードを削除