### PR TITLE
feat: 1台のVMが常時起動状態になるようにfly.tomlを変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,7 +22,7 @@ worker = "bundle exec sidekiq"
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
 [env]
   TZ = "Asia/Tokyo"


### PR DESCRIPTION
## 変更の概要

* fly.tomlを変更してVMが1台常時起動しているように変更
* 関連するIssueやプルリクエスト　なし

## なぜこの変更をするのか
* `fly launch`で作成されるデフォルトのfly.tomlファイルを使用すると、しばらくリクエストがないとVMが自動停止してしまい、リクエストがあったときにVMの再起動が必要となるので、ユーザー体験が悪くなる。これを解消する。

## やったこと

* [x] fly.tomlファイルの`min_machines_running = 0`を`min_machines_running = 1`へ変更

## 参考

* https://fly.io/docs/apps/autostart-stop/#when-to-stop-and-start-fly-machines-automatically-or-not
