### PR TITLE
feat: sidekiqからRedisへ送られるクエリの制御設定を変更

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,9 @@
 # SidekiqのRedis接続設定
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_URL'] }
+  Sidekiq::BasicFetch::TIMEOUT = 60
+  Sidekiq::Launcher.send(:remove_const, 'BEAT_PAUSE')
+  Sidekiq::Launcher.const_set('BEAT_PAUSE', 55)
 end
 
 Sidekiq.configure_client do |config|

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,3 +6,9 @@
     weekly_floss_summary_job:
       cron: "0 0 7 * * 0"
       class: WeeklyFlossSummaryJob
+
+:concurrency: 3
+:queues:
+	- default
+:retry: 5
+:poll_interval_average: 60


### PR DESCRIPTION
## 変更の概要

*sidekiqのポーリング間隔、ハートビート間隔の設定を変更して、Redisのデイリー上限を超えないようにした
* 関連するIssueやプルリクエスト close: #119 

## なぜこの変更をするのか

* fly.ioのUpstashのRedisの無料枠ではデイリーのリクエスト上限が10,000リクエストとなっている。
* sidekiqのポーリング間隔がデフォルトでは5秒になっているが、sidekiqがRedisにジョブを確認にいくことで発生するコマンドがリクエストとしてカウントされるため、1日立たずにリクエスト上限に達してしまっていた。
* 1日1回の定期実行ジョブを行うためには上限の10,000リクエストにならないように設定を変更する必要がある。

## やったこと

* [x] `config/sidekiq.yml`にポーリング間隔を制御するコードを既述
* [x] `config/initializer/sidekiq.rb`に sidekiqのプロセスが起動したときのコードを既述
