### PR TITLE
feat: sidekiq.ymlの既述を入れ替え

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,7 @@
+:concurrency: 3
+:retry: 5
+:poll_interval_average: 60
+
 :scheduler:
   :schedule:
     floss_reminder_job:
@@ -6,9 +10,3 @@
     weekly_floss_summary_job:
       cron: "0 0 7 * * 0"
       class: WeeklyFlossSummaryJob
-
-:concurrency: 3
-:queues:
-	- default
-:retry: 5
-:poll_interval_average: 60


### PR DESCRIPTION
デプロイエラーが出たので、`sidekiq.yml`から原因と思われる下記の既述を削除。
```
:queues: 
	- default
```

もう一度デプロイして、別のエラーが発生したが、日を変えたら何故かデプロイできた。
Upstashのコンソールを見るとコマンド数が減っているのでsidekiqの設定変更できているよう。